### PR TITLE
Apply trimmed weights to Figure 5 and Figure 6

### DIFF
--- a/code/figure5_id_qc_can.R
+++ b/code/figure5_id_qc_can.R
@@ -3,11 +3,11 @@ library(dplyr)
 library(ggplot2)
 
 # Data -------------------------------------------------------------------
-data <- readRDS("SharedFolder_spsa_article_nationalisme/data/merged_v1.rds") %>% 
+data <- readRDS("SharedFolder_spsa_article_nationalisme/data/merged_v2.rds") %>%
   filter(
     year >= 2021 &
     source_id %in% c("january", "february", "march", "april", "may", "june")
-  ) |> 
+  ) |>
   mutate(yob = year - ses_age,
          generation = case_when(
            yob %in% 1925:1946 ~ "preboomer",
@@ -17,18 +17,31 @@ data <- readRDS("SharedFolder_spsa_article_nationalisme/data/merged_v1.rds") %>%
            yob %in% 1992:2003 ~ "z"
          ),
          generation = factor(generation)) |>
-  tidyr::drop_na(generation, iss_idcan)
+  tidyr::drop_na(generation, iss_idcan, weight_trimmed)
 
-data |> 
-  group_by(generation, iss_idcan) |> 
+# Calculate effective sample size by generation for CIs
+n_eff_by_gen <- data |>
+  group_by(generation) |>
   summarise(
-    n = n()
-  ) |> 
-  group_by(generation) |> 
+    n_eff = sum(weight_trimmed)^2 / sum(weight_trimmed^2),
+    .groups = "drop"
+  )
+
+data |>
+  group_by(generation, iss_idcan) |>
+  summarise(
+    n = sum(weight_trimmed),
+    .groups = "drop_last"
+  ) |>
+  group_by(generation) |>
   mutate(
     total = sum(n),
-    prop = n / total,
-    margin_error = 1.96 * sqrt((prop * (1 - prop)) / total),
+    prop = n / total
+  ) |>
+  ungroup() |>
+  left_join(n_eff_by_gen, by = "generation") |>
+  mutate(
+    margin_error = 1.96 * sqrt((prop * (1 - prop)) / n_eff),
     ci_lower = prop - margin_error,
     ci_upper = prop + margin_error,
     generation = factor(
@@ -36,7 +49,7 @@ data |>
       levels = rev(c("preboomer", "boomer", "x", "y", "z")),
       labels = rev(c("Preboomer", "Boomer", "X", "Y", "Z"))
     )
-  ) |> 
+  ) |>
   filter(iss_idcan == 0) |> 
   ggplot(
     aes(x = prop, y = generation)
@@ -46,7 +59,7 @@ data |>
     aes(xmin = ci_lower, xmax = ci_upper),
     linewidth = 0.1
   ) +
-  clessnize::theme_clean_light() +
+  clessnverse::theme_clean_light() +
   scale_x_continuous(
     limits = c(0.45, 0.75),
     breaks = seq(0, 100, by = 10)/100,

--- a/code/figure6_appendix.R
+++ b/code/figure6_appendix.R
@@ -13,7 +13,7 @@ options(modelsummary_factory_default = "kableExtra")
 options(knitr.table.format = "latex")
 
 # Data -------------------------------------------------------------------
-data <- readRDS("SharedFolder_spsa_article_nationalisme/data/merged_v1.rds") %>%
+data <- readRDS("SharedFolder_spsa_article_nationalisme/data/merged_v2.rds") %>%
   filter(
     year >= 2021 &
     source_id %in% c("january", "february", "march", "april", "may", "june")
@@ -35,14 +35,15 @@ data$attitude_strength[data$iss_souv2 %in% c(0.25, 0.33, 0.5, 0.66, 0.75)] <- 0
 
 # Model data - separate for with/without controls to maximize N
 model_data_no_controls <- data |>
-  select(attitude_strength, generation, iss_idcan) |>
+  select(attitude_strength, generation, iss_idcan, weight_trimmed) |>
   tidyr::drop_na()
 
 model_data_with_controls <- data |>
   select(
     attitude_strength, generation, iss_idcan,
     ses_lang.1, ses_gender, ses_family_income_centile_cat,
-    ses_origin_from_canada.1, ses_educ
+    ses_origin_from_canada.1, ses_educ,
+    weight_trimmed
   ) |>
   tidyr::drop_na()
 
@@ -52,7 +53,8 @@ model_data_with_controls <- data |>
 model_no_controls <- glm(
   attitude_strength ~ generation * iss_idcan,
   data = model_data_no_controls,
-  family = binomial()
+  family = binomial(),
+  weights = weight_trimmed
 )
 
 # Model 2: With controls (logistic)
@@ -60,7 +62,8 @@ model_with_controls <- glm(
   attitude_strength ~ generation * iss_idcan + ses_lang.1 + ses_gender +
     ses_family_income_centile_cat + ses_origin_from_canada.1 + ses_educ,
   data = model_data_with_controls,
-  family = binomial()
+  family = binomial(),
+  weights = weight_trimmed
 )
 
 # Create comparison table -------------------------------------------------
@@ -162,6 +165,6 @@ tab_latex <- kableExtra::kbl(
   kableExtra::kable_styling(latex_options = c("hold_position"))
 
 writeLines(as.character(tab_latex),
-           "SharedFolder_spsa_article_nationalisme/tables/appendix/figure5_regression_table.tex")
+           "SharedFolder_spsa_article_nationalisme/tables/appendix/figure6_regression_table.tex")
 
-message("Table saved to SharedFolder_spsa_article_nationalisme/tables/appendix/figure5_regression_table.tex")
+message("Table saved to SharedFolder_spsa_article_nationalisme/tables/appendix/figure6_regression_table.tex")


### PR DESCRIPTION
## Summary
- Apply trimmed weights to Figure 5 (identity proportions) and Figure 6 (attitude strength by identity)
- `figure5_id_qc_can.R`: Use weighted proportions with effective sample size for confidence intervals
- `figure6_attitude_force_idcan.R`: Add `weights = weight_trimmed` to logistic regression
- `figure6_appendix.R`: Add weights to both models, fix output filename (was figure5, now figure6)
- All scripts now use `merged_v2.rds` and `clessnverse::theme_clean_light()` for consistency

## Test plan
- [x] Run `figure5_id_qc_can.R` - generates weighted proportion graph
- [x] Run `figure6_attitude_force_idcan.R` - generates weighted logistic regression predictions
- [x] Run `figure6_appendix.R` - generates LaTeX regression table

🤖 Generated with [Claude Code](https://claude.com/claude-code)